### PR TITLE
Use markdownlint-cli2 on pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  ruby: 2.7.2
-
 repos:
   - repo: local
     hooks:
@@ -16,7 +13,7 @@ repos:
         language: system
         types: [text]
         pass_filenames: false
-  - repo: https://github.com/markdownlint/markdownlint
-    rev: v0.13.0
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.10.0
     hooks:
-      - id: markdownlint
+      - id: markdownlint-cli2


### PR DESCRIPTION
Hook `markdownlint/markdownlint` is not affected by `.markdownlint.json`. Changed to `markdownlint-cli2`.